### PR TITLE
Improve error logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -410,6 +410,18 @@ section.  An appropriate title should be specified for each form.
 Nested markup required to enable the animated loading progress bar
 without requiring any external graphics.
 
+        <div id="err">
+          <div id="worried-face">&#x1F61F;</div>
+          <div>
+            <h1>Something went wrong.</h1>
+            The following log information may help resolve the problem.
+            <div id="error-log"></div>
+          </div>
+        </div>
+
+Markup required for logging errors that occur during Javascript
+execution so that they can be presented to the user appropriately.
+
         <form id="the-form" name="the-form">
            ...
         </form>

--- a/form-los-altos-da.html
+++ b/form-los-altos-da.html
@@ -13,8 +13,16 @@
   </head>
 
   <body>
-    <div class="version">0.1.0</div>
+    <div class="version">0.1.1</div>
     <div id="loading"><div>Loading<div id="spin"><div id="spin_1" class="spin"></div></div></div></div>
+    <div id="err">
+      <div id="worried-face">&#x1F61F;</div>
+      <div>
+        <h1>Something went wrong.</h1>
+        The following log information may help resolve the problem.
+        <div id="error-log"></div>
+      </div>
+    </div>
     <form id="the-form" name="the-form">
       <div data-include-html="ics-header">
         {

--- a/resources/css/loading.css
+++ b/resources/css/loading.css
@@ -19,7 +19,7 @@
     left:0;
     width:100%;
     height:100%;
-    z-index:9999;
+    z-index:9998;
     background-color:#eeeeee;
     visibility: visible;
     transition: visibility 0s 0.5s,opacity 0.5s;

--- a/resources/css/pack-it-forms.css
+++ b/resources/css/pack-it-forms.css
@@ -223,6 +223,69 @@ td.border-left {
     padding-right: 0.5em;
 }
 
+/* Error logging/presentation */
+
+#err {
+    background-color: #eeeeee;
+    color: #888888;
+    display: none;
+}
+
+#err.occured {
+    display: block;
+    position: fixed;
+    top: 0px;
+    left: 0px;
+    width: 96%;
+    margin-left: 2%;
+    margin-right: 2%;
+    margin-top: 4em;
+    border: 2px solid black;
+    padding: 1ex 0 0.5em;
+    visibility: visible;
+    opacity: 1.0;
+    z-index: 9999;
+}
+
+#err h1 {
+    padding-top: 14pt;
+    padding-bottom: 0;
+    margin-bottom: 0;
+}
+
+#worried-face {
+    float: left;
+    font-size: 48pt;
+}
+
+#error-log {
+    clear: left;
+    margin-top: 2ex;
+    margin-left: 1em;
+    margin-right: 1em;
+    margin-bottom: 1ex;
+    font-family: monospace;
+    padding-top: 1ex;
+    font-size: 10pt;
+    border-top: 1px solid #888888;
+    white-space: pre;
+}
+
+#error-indicator {
+    visibility: hidden;
+    background-color: #ffaaaa;
+    color: #444444;
+    font-weight: bold;
+    display: inline;
+    padding: 0.25ex 1em;
+    position: fixed;
+    top: 1ex;
+    right: 1em;
+}
+
+#error-indicator.occured {
+    visibility: visible;
+}
 
 /* Form validation */
 

--- a/resources/html/submit-buttons.html
+++ b/resources/html/submit-buttons.html
@@ -1,5 +1,5 @@
 <div>
-  <div class="version">0.1.0</div>
+  <div class="version">0.1.1</div>
   <div id="button-header">
     <input id="show-hide-data" type="button" value="Show Data Message"
            onclick="toggle_form_data_visibility();" form="the-form"/>
@@ -9,6 +9,7 @@
            value="Submit via Email" form="the-form"  disabled="disabled"/>
     <input id="clear-form" type="button" value="Clear the form"
            onclick="clear_form();"/>
+    <div id="error-indicator">Error</div>
   </div>
   <form id="form-data-form" method="post" action="http://127.0.0.1:9334/send">
     <textarea id="form-data" name="formtext" class="hidden"></textarea>

--- a/resources/js/pack-it-forms.js
+++ b/resources/js/pack-it-forms.js
@@ -218,16 +218,45 @@ function parse_form_data_text(text) {
     return fields;
 }
 
-function FormDataParseException(linenum, desc) {
-    this.name = "FormDataParseException";
-    this.linenum = linenum;
-    this.message = "Parse error on line " + linenum.toString() + ": " + desc;
+function FormDataParseError(linenum, desc) {
+    var msgtext = "Parse error on line " + linenum.toString() + ": " + desc;
+
+    Object.defineProperty(this, 'name', {
+        enumerable: false,
+        writable: false,
+        value: "FormDataParseError"
+    });
+
+    Object.defineProperty(this, 'linenum', {
+        enumerable: false,
+        writable: false,
+        value: linenum
+    });
+
+    Object.defineProperty(this, 'message', {
+        enumerable: false,
+        writable: true,
+        value: msgtext
+    });
+
+    if (Error.hasOwnProperty('captureStackTrace')) {
+        Error.captureStackTrace(this, FormDataParseError);
+    } else {
+        Object.defineProperty(this, 'stack', {
+            enumerable: false,
+            writable: false,
+            value: (new Error(msgtext)).stack
+        });
+    }
 }
+FormDataParseError.prototype = Object.create(Error.prototype, {
+    constructor: { value: FormDataParseError }
+});
 
 function index_of_field_name_sep(linenum, line, startAt) {
     var idx = line.indexOf(":", startAt);
     if (idx == -1) {
-        throw new FormDataParseException(linenum, "no field name/value separator on line");
+        throw new FormDataParseError(linenum, "no field name/value separator on line");
     }
     return idx;
 }
@@ -235,7 +264,7 @@ function index_of_field_name_sep(linenum, line, startAt) {
 function index_of_field_value_start(linenum, line, startAt) {
     var idx = line.indexOf("[", startAt);
     if (idx == -1) {
-        throw new FormDataParseException(linenum, "no field value open bracket");
+        throw new FormDataParseError(linenum, "no field value open bracket");
     }
     return idx;
 }

--- a/resources/js/pack-it-forms.js
+++ b/resources/js/pack-it-forms.js
@@ -1197,6 +1197,80 @@ function remove_loading_overlay(next) {
     next();
 }
 
+function loadingComplete() {
+    var el = document.querySelector("#loading");
+    return el.classList.contains("done");
+}
+
+function showErrorLog() {
+    var el = document.querySelector("#err");
+    el.classList.add("occured");
+}
+
+function hideErrorLog() {
+    var el = document.querySelector("#err");
+    el.classList.remove("occured");
+}
+
+function toggleErrorLog() {
+    var el = document.querySelector("#err");
+    if (el.classList.contains("occured")) {
+        el.classList.remove("occured");
+    } else {
+        el.classList.add("occured");
+    }
+}
+
+function showErrorIndicator() {
+    var el = document.querySelector("#error-indicator");
+    el.classList.add("occured");
+}
+
+function hideErrorIndicator() {
+    var el = document.querySelector("#error-indicator");
+    el.classList.remove("occured");
+}
+
+function setup_error_indicator(next) {
+    var el = document.querySelector("#error-indicator");
+    el.onclick = toggleErrorLog;
+    next();
+}
+
+function indicateError() {
+    if (loadingComplete()) {
+        showErrorIndicator();
+    } else {
+        showErrorLog();
+    }
+}
+
+function logError(msg) {
+    var el = document.querySelector("#error-log");
+    el.textContent = el.textContent + msg + "\n";
+    indicateError();
+}
+
+window.addEventListener('error', function(event) {
+    //if (event.hasAnyProperty('error') && event.error.hasOwnProperty('stack')) {
+    logError(event.message
+             + " ("
+             + (event.url ? event.url : "")
+             + (event.lineno ? ":" + event.lineno : "")
+             + (event.colno ? ":" + event.colno : "")
+             + ")");
+    if ("error" in event && event.error &&  "stack" in event.error) {
+        logError(event.error.stack)
+    }
+    return false;
+});
+
+/* This is for testing error logging during startup */
+function test_error(next) {
+    throw new FormDataParseError(10, "This is a test error.");
+    next();
+}
+
 /* This is for testing the loading overlay */
 function startup_delay(next) {
     window.setTimeout(function () {
@@ -1216,4 +1290,6 @@ startup_functions.push(init_form);
 startup_functions.push(setup_view_mode);
 // These must be the last startup functions added
 //startup_functions.push(startup_delay);  // Uncomment to test loading overlay
+//startup_functions.push(test_error);  // Uncomment to test startup err report
+startup_functions.push(setup_error_indicator);
 startup_functions.push(remove_loading_overlay);


### PR DESCRIPTION
Catch and log errors that occur to assist in troubleshooting.  When an error occurs during initialization the log is shown immediately:

![error-log-during-initialization](https://user-images.githubusercontent.com/7191814/44304942-5ed37f00-a320-11e8-8fa2-59ac96c98c4d.png)

When an error occurs after initialization the form may still be usable so a subtle "error" indication is shown in the upper-right of the form:

![error-indicatior-after-initialization-log-closed](https://user-images.githubusercontent.com/7191814/44304945-790d5d00-a320-11e8-9457-78be4abeef99.png)

Clicking on the error indicator toggles the visibility of an error log:

![error-indicatior-after-initialization-log-open](https://user-images.githubusercontent.com/7191814/44304948-89bdd300-a320-11e8-8c77-5c21176f39d5.png)
