### PR TITLE
Sender's Message Number

### DIFF
--- a/resources/html/ics-header.html
+++ b/resources/html/ics-header.html
@@ -6,7 +6,7 @@
       <td>
         <label>Sender's Msg #<span class="field-number">2</span>
           <input name="2.txmsgno" class="" type="text"
-                 value="{{msg-field:MsgNo}}"/>
+                 value="{{query-string:txmsgno}}"/>
         </label>
       </td><td>
         <label>My Msg #:

--- a/resources/js/pack-it-forms.js
+++ b/resources/js/pack-it-forms.js
@@ -176,6 +176,16 @@ form data message, which is passed in as text.  It is implemented as a
 wrapper around init_form_from_fields. */
 function init_form_from_msg_data(text) {
     msgfields = parse_form_data_text(text);
+    if (msgfields.MsgNo) {
+        var status = query_object.message_status;
+        if (status == 'new' || status == 'draft' || status == 'ready' || status == 'sent') {
+            // I sent this message.
+            query_object.msgno = msgfields.MsgNo; // show My Msg #
+        } else {
+            // I received this message.
+            query_object.txmsgno = msgfields.MsgNo; // show the Sender's Msg #
+        }
+    }
     init_form_from_fields(msgfields, "name", "msg-value");
 }
 


### PR DESCRIPTION
There are at least two somewhat arbitrary choices here: how to know whether a message was sent or received, and how to initialize the 'Sender's Msg #' field (for a received message). I chose a query string parameter 'message_status' to indicate sent or received, and a query string parameter 'txmsgno' to initialize the 'Sender's Msg #' field. These work conveniently with OutpostForLAARES, but I'm open to other ideas for either choice.

The values of message_status are drawn from names in the Outpost add-on interface. The other possible values are 'unread' and 'read', which both indicate a received message.