### PR TITLE
no placeholders when readonly

### DIFF
--- a/resources/js/pack-it-forms.js
+++ b/resources/js/pack-it-forms.js
@@ -1035,6 +1035,9 @@ function setup_view_mode(next) {
            style it and hide the textarea. */
         var textareas_to_redisplay = [];
         array_for_each(form.elements, function (el) {
+            if (el.placeholder) {
+                el.placeholder = '';
+            }
             if (el.type == "radio"
                 || el.type == "checkbox"
                 || (el.type && el.type.substr(0, 6) == "select")) {


### PR DESCRIPTION
Internet Explorer (version 11) displays and prints placeholders in disabled text inputs, for example when viewing a received message. So a receiving operator will mistake a placeholder for information entered by the sender.